### PR TITLE
ENH: subclassing piecewise polynomials

### DIFF
--- a/scipy/interpolate/interpolate.py
+++ b/scipy/interpolate/interpolate.py
@@ -3,7 +3,7 @@
 from __future__ import division, print_function, absolute_import
 
 __all__ = ['interp1d', 'interp2d', 'spline', 'spleval', 'splmake', 'spltopp',
-           'ppform', 'lagrange', 'PPoly', 'BPoly']
+           'ppform', 'lagrange', 'PPoly', 'BPoly', 'bpoly_from_derivatives']
 
 from numpy import shape, sometrue, array, transpose, searchsorted, \
                   ones, logical_or, atleast_1d, atleast_2d, ravel, \
@@ -1132,121 +1132,6 @@ class BPoly(_PPolyBase):
 
         return cls.construct_fast(c, pp.x, extrapolate)
 
-    @classmethod
-    def from_derivatives(cls, xi, yi, orders=None, direction=None,
-                         axis=0, extrapolate=None):
-        """Construct a piecewise polynomial in the Bernstein basis,
-        compatible with the specified values and derivatives at breakpoints.
-
-        Parameters
-        ----------
-        xi : array_like
-            sorted 1D array of x-coordinates
-        yi : array_like or list of array-likes
-            `yi[i][j]` is the `j`-th derivative known at `xi[i]`
-        orders : None or int or array_like of ints. Default: None.
-            Specifies the degree of local polynomials. If not None, some
-            derivatives are ignored. 
-        axis : int, optional
-            Interpolation axis, default is 0.
-        extrapolate : bool, optional
-            Whether to extrapolate to ouf-of-bounds points based on first
-            and last intervals, or to return NaNs. Default: True.        
-
-        Notes
-        -----
-        If `k` derivatives are specified at a breakpoint `x`, the
-        constructed polynomial is exactly `k` times continuously 
-        differentiable at `x`, unless the `order` is provided explicitly.
-        In the latter case, the smoothness of the polynomial at
-        the breakpoint is controlled by the `order`.
-        
-        Deduces the number of derivatives to match at each end
-        from `order` and the number of derivatives available. If
-        possible it uses the same number of derivatives from
-        each end; if the number is odd it tries to take the
-        extra one from y2. In any case if not enough derivatives
-        are available at one end or another it draws enough to
-        make up the total from the other end.
-        
-        If the order is too high and not enough derivatives are available,
-        an exception is raised.
-
-        Examples
-        --------
-
-        >>> BPoly.from_derivatives([[1, 2], [3, 4]], [0, 1])
-
-        Creates a polynomial `f(x)` of degree 3, defined on `[0, 1]`
-        such that `f(0) = 1, df/dx(0) = 2, f(1) = 3, df/dx(1) = 4`
-
-        >>> BPoly.from_derivatives([[0, 1], [0], [2], [0, 1, 2])
-
-        Creates a piecewise polynomial `f(x)`, such that
-        `f(0) = f(1) = 0`, `f(2) = 2`, and `df/dx(0) = 1`.
-        Based on the number of derivatives provided, the order of the
-        local polynomials is 2 on `[0, 1]` and 1 on `[1, 2]`.
-        Notice that no restriction is imposed on the derivatives at
-        `x = 1` and `x = 2`.
-
-        Indeed, the explicit form of the polynomial is
-        f(x) = | x * (1 - x),  0 <= x < 1
-               | 2 * (x - 1),  1 <= x <= 2
-        So that f'(1-0) = -1 and f'(1+0) = 2
-
-        """
-        if axis != 0:
-            raise NotImplementedError
-        if direction is not None:
-            raise NotImplementedError
-            
-        xi = np.asarray(xi)
-        if len(xi) != len(yi):
-            raise ValueError("xi and yi need to have the same length")
-        if np.any(xi[1:] - xi[:1] <= 0):
-            raise ValueError("x coordinates are not in increasing order")
-
-        # number of intervals
-        m = len(xi) - 1
-
-        # global poly order is k-1, local orders are <=k and can vary
-        k = max(len(yi[i]) + len(yi[i+1]) for i in range(m))
-        if orders is None:
-            orders = [None] * m
-        else:
-            if isinstance(orders, integer_types):
-                orders = [orders] * m
-            k = max(k, max(orders))
-            
-            if any(o <= 0 for o in orders):
-                raise ValueError("Orders must be positive.")
-
-        c = []
-        for i in range(m):
-            y1, y2 = yi[i], yi[i+1]
-            if orders[i] is None:
-                n1, n2 = len(y1), len(y2)
-            else:
-                n = orders[i]+1
-                n1 = min(n//2, len(y1))
-                n2 = min(n - n1, len(y2))
-                n1 = min(n - n2, len(y2))
-                if n1+n2 != n:
-                    raise ValueError("Point %g has %d derivatives, point %g"
-                            " has %d derivatives, but order %d requested" %
-                            (xi[i], len(y1), xi[i+1], len(y2), orders[i]))
-                if not (n1 <= len(y1) and n2 <= len(y2)):
-                    raise ValueError("`order` input incompatible with"
-                            " length y1 or y2.")
-
-            b = BPoly._construct_from_derivatives(xi[i], xi[i+1],  y1[:n1], y2[:n2])
-            if len(b) < k:
-                b = BPoly._raise_degree(b, k - len(b))
-            c.append(b)
-
-        c = np.asarray(c)
-        return cls(c.swapaxes(0, 1), xi, extrapolate)
-
     @staticmethod
     def _construct_from_derivatives(xa, xb, ya, yb):
         """Compute the coefficients of a polynomial in the Bernstein basis 
@@ -1372,6 +1257,123 @@ class BPoly(_PPolyBase):
             for j in range(d+1):
                 out[a+j] += f * comb(d, j) / comb(k+d, a+j)
         return out
+
+
+def bpoly_from_derivatives(xi, yi, orders=None, direction=None,
+                         axis=0, extrapolate=None, cls=BPoly):
+    """Construct a piecewise polynomial in the Bernstein basis,
+    compatible with the specified values and derivatives at breakpoints.
+
+    Parameters
+    ----------
+    xi : array_like
+        sorted 1D array of x-coordinates
+    yi : array_like or list of array-likes
+        `yi[i][j]` is the `j`-th derivative known at `xi[i]`
+    orders : None or int or array_like of ints. Default: None.
+        Specifies the degree of local polynomials. If not None, some
+        derivatives are ignored. 
+    axis : int, optional
+        Interpolation axis, default is 0.
+    extrapolate : bool, optional
+        Whether to extrapolate to ouf-of-bounds points based on first
+        and last intervals, or to return NaNs. Default: True.
+    cls : a subclass of BPoly
+        An instance of cls is returned. Default: BPoly.
+
+    Notes
+    -----
+    If `k` derivatives are specified at a breakpoint `x`, the
+    constructed polynomial is exactly `k` times continuously 
+    differentiable at `x`, unless the `order` is provided explicitly.
+    In the latter case, the smoothness of the polynomial at
+    the breakpoint is controlled by the `order`.
+    
+    Deduces the number of derivatives to match at each end
+    from `order` and the number of derivatives available. If
+    possible it uses the same number of derivatives from
+    each end; if the number is odd it tries to take the
+    extra one from y2. In any case if not enough derivatives
+    are available at one end or another it draws enough to
+    make up the total from the other end.
+    
+    If the order is too high and not enough derivatives are available,
+    an exception is raised.
+
+    Examples
+    --------
+
+    >>> bpoly_from_derivatives([[1, 2], [3, 4]], [0, 1])
+
+    Creates a polynomial `f(x)` of degree 3, defined on `[0, 1]`
+    such that `f(0) = 1, df/dx(0) = 2, f(1) = 3, df/dx(1) = 4`
+
+    >>> bpoly_from_derivatives([[0, 1], [0], [2], [0, 1, 2])
+
+    Creates a piecewise polynomial `f(x)`, such that
+    `f(0) = f(1) = 0`, `f(2) = 2`, and `df/dx(0) = 1`.
+    Based on the number of derivatives provided, the order of the
+    local polynomials is 2 on `[0, 1]` and 1 on `[1, 2]`.
+    Notice that no restriction is imposed on the derivatives at
+    `x = 1` and `x = 2`.
+
+    Indeed, the explicit form of the polynomial is
+    f(x) = | x * (1 - x),  0 <= x < 1
+           | 2 * (x - 1),  1 <= x <= 2
+    So that f'(1-0) = -1 and f'(1+0) = 2
+
+    """
+    if axis != 0:
+        raise NotImplementedError
+    if direction is not None:
+        raise NotImplementedError
+        
+    xi = np.asarray(xi)
+    if len(xi) != len(yi):
+        raise ValueError("xi and yi need to have the same length")
+    if np.any(xi[1:] - xi[:1] <= 0):
+        raise ValueError("x coordinates are not in increasing order")
+
+    # number of intervals
+    m = len(xi) - 1
+
+    # global poly order is k-1, local orders are <=k and can vary
+    k = max(len(yi[i]) + len(yi[i+1]) for i in range(m))
+    if orders is None:
+        orders = [None] * m
+    else:
+        if isinstance(orders, integer_types):
+            orders = [orders] * m
+        k = max(k, max(orders))
+        
+        if any(o <= 0 for o in orders):
+            raise ValueError("Orders must be positive.")
+
+    c = []
+    for i in range(m):
+        y1, y2 = yi[i], yi[i+1]
+        if orders[i] is None:
+            n1, n2 = len(y1), len(y2)
+        else:
+            n = orders[i]+1
+            n1 = min(n//2, len(y1))
+            n2 = min(n - n1, len(y2))
+            n1 = min(n - n2, len(y2))
+            if n1+n2 != n:
+                raise ValueError("Point %g has %d derivatives, point %g"
+                        " has %d derivatives, but order %d requested" %
+                        (xi[i], len(y1), xi[i+1], len(y2), orders[i]))
+            if not (n1 <= len(y1) and n2 <= len(y2)):
+                raise ValueError("`order` input incompatible with"
+                        " length y1 or y2.")
+
+        b = BPoly._construct_from_derivatives(xi[i], xi[i+1],  y1[:n1], y2[:n2])
+        if len(b) < k:
+            b = BPoly._raise_degree(b, k - len(b))
+        c.append(b)
+
+    c = np.asarray(c)
+    return cls(c.swapaxes(0, 1), xi, extrapolate)
 
 
 # backward compatibility wrapper


### PR DESCRIPTION
This is the next last of the final touches :-). Hopefully the very last indeed. 

Currently, subclasses of both PPoly and BPoly decay to base classes at a slightest touch: 

```
>>> from scipy.interpolate import PPoly
>>> class P(PPoly):
...    pass
... 
>>> p = P([[0]], [0, 1])
>>> pd = p.derivative()
>>> type(pd)
<class 'scipy.interpolate.interpolate.PPoly'>
>>> type(p)
<class '__main__.P'>
>>> 
```

Which is what this PR fixes. 

Here's an example usage of subclassing: https://github.com/EvgeniBurovski/piecewise_p/blob/master/PBC.py
Reasonably elegant IMO, but that might be a matter of taste.

I see still two glitches with this sort of approach (with or without mixins, they are just a detail): 
1) `extrapolate` argument of the `__call__` method. Esp if subclassing is a way of specifying the out-of-bounds behavior. 
2) `BPoly.from_derivatives` needs to be a @classmethod constructor; it can thus be called with an instance:

```
>>> p = BPoly(...)
>>> p.from_derivatives(xi, yi)
```

a user might think it's going to modify the existing object `p`, but it'll return a fresh instance instead.

I'm inclined to dismiss 2) as a user error. Maybe it could be stressed in the docstring, but I don't even see how. 

1) is a bit more serious. It's the same issue we discussed earlier, with extrapolation or filling with nans being first-class behavior, and anything else being bolted on. I don't see a clean way out: the abstraction seems to leak this way or another. At least the behavior with this PR keeps being consistent, and an override requires a user action, and a user is a consenting adult etc. Maybe this deserves a mention in the module / class docstring though. 

An alternative could be to prohibit subclassing altogether, but I'm not sure it is even possible in python.

All this assumes there's no glaring problem I don't see and you do. And if you do, I'm all ears :-)
